### PR TITLE
Fixed little Namespace typo Inline InLine

### DIFF
--- a/src/Creative/InLine/Linear.php
+++ b/src/Creative/InLine/Linear.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sokil\Vast\Creative\Inline;
+namespace Sokil\Vast\Creative\InLine;
 
 use Sokil\Vast\Creative\AbstractLinearCreative;
 use Sokil\Vast\Creative\InLine\Linear\MediaFile;


### PR DESCRIPTION
Found this little typo while requiring the new version inside of my symfony project.