### PR TITLE
Corrent namespace Ad class

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -156,7 +156,7 @@ class Document extends AbstractNode
                 $type = $node->tagName;
 
                 // create ad section
-                $adTypeClassName = '\\Sokil\\Vast\\AbstractAdNode\\' . $type;
+                $adTypeClassName = '\\Sokil\\Vast\\Ad\\' . $type;
                 if (!class_exists($adTypeClassName)) {
                     throw new \Exception('Ad type ' . $type . ' not supported');
                 }


### PR DESCRIPTION
namespace `Sokil\Vast\AbstractAdNode` does not exist