### PR TITLE
Add custom attributes to mediafile

### DIFF
--- a/src/Creative/InLine/Linear/MediaFile.php
+++ b/src/Creative/InLine/Linear/MediaFile.php
@@ -54,6 +54,13 @@ class MediaFile
         return $this;
     }
 
+    public function setCustom($attribute, $value)
+    {
+        $this->domElement->setAttribute($attribute, $value);
+
+        return $this;
+    }
+
     public function setUrl($url)
     {
         $cdata = $this->domElement->ownerDocument->createCDATASection($url);

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -46,6 +46,46 @@ class DocumentTest extends AbstractTestCase
     }
 
     /**
+     * Test for custom attribute
+     */
+    public function testCustomCreateInLineAdSection()
+    {
+        $factory = new Factory();
+        $document = $factory->create('4.1');
+        $this->assertInstanceOf('\\Sokil\\Vast\\Document', $document);
+
+        // insert Ad section
+        $ad1 = $document
+            ->createInLineAdSection()
+            ->setId('ad1')
+            ->setAdSystem('Ad Server Name')
+            ->setAdTitle('Ad Title')
+            ->addImpression('http://ad.server.com/impression', 'imp1');
+
+        // create creative for ad section
+        $ad1
+            ->createLinearCreative()
+            ->setDuration(128)
+            ->setUniversalAdId('ad-server.com', '15051996')
+            ->setVideoClicksClickThrough('http://entertainmentserver.com/landing')
+            ->addVideoClicksClickTracking('http://ad.server.com/videoclicks/clicktracking')
+            ->addVideoClicksCustomClick('http://ad.server.com/videoclicks/customclick')
+            ->addTrackingEvent('start', 'http://ad.server.com/trackingevent/start')
+            ->addTrackingEvent('pause', 'http://ad.server.com/trackingevent/stop')
+            ->addProgressTrackingEvent('http://ad.server.com/trackingevent/progress', 10)
+            ->createMediaFile()
+                ->setProgressiveDelivery()
+                ->setType('video/mp4')
+                ->setHeight(100)
+                ->setWidth(100)
+                ->setBitrate(600)
+                ->setCustom('minBitrate', 700)
+                ->setUrl('http://server.com/media.mp4');
+
+        $this->assertVastDocumentSameWithXmlFixture('inlineAdCustom.xml', $document);
+    }
+
+    /**
      * Test for inline ad
      */
     public function testReplaceVideoClicksClickThrough()

--- a/tests/data/inlineAdCustom.xml
+++ b/tests/data/inlineAdCustom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="4.1">
+    <Ad id="ad1">
+        <InLine>
+            <AdSystem><![CDATA[Ad Server Name]]></AdSystem>
+            <AdTitle><![CDATA[Ad Title]]></AdTitle>
+            <Impression id="imp1"><![CDATA[http://ad.server.com/impression]]></Impression>
+            <Creatives>
+                <Creative>
+                    <UniversalAdId idRegistry="ad-server.com">15051996</UniversalAdId>
+                    <Linear>
+                        <Duration>00:02:08</Duration>
+                        <VideoClicks>
+                            <ClickThrough><![CDATA[http://entertainmentserver.com/landing]]></ClickThrough>
+                            <ClickTracking><![CDATA[http://ad.server.com/videoclicks/clicktracking]]></ClickTracking>
+                            <CustomClick><![CDATA[http://ad.server.com/videoclicks/customclick]]></CustomClick>
+                        </VideoClicks>
+                        <TrackingEvents>
+                            <Tracking event="start"><![CDATA[http://ad.server.com/trackingevent/start]]></Tracking>
+                            <Tracking event="pause"><![CDATA[http://ad.server.com/trackingevent/stop]]></Tracking>
+                            <Tracking event="progress" offset="00:00:10"><![CDATA[http://ad.server.com/trackingevent/progress]]></Tracking>
+                        </TrackingEvents>
+                        <MediaFiles>
+                            <MediaFile delivery="progressive" type="video/mp4" height="100" width="100" bitrate="600" minBitrate="700">
+                                <![CDATA[http://server.com/media.mp4]]></MediaFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+            </Creatives>
+        </InLine>
+    </Ad>
+</VAST>


### PR DESCRIPTION
First of all great work Sokil!

The only problem I have that this package isn't that flexible. For example: every attribute for a MediaFile has it's own function. I could have written more functions, but I wanted something more flexible.

So I created a "custom" attribute function where you could pass in everything you want. Of course this means you could break the VAST tag spec, but that's a users own choice.