### PR TITLE
Add support for InteractiveCreativeFile as per 4.1 VAST specification

### DIFF
--- a/src/Creative/InLine/Linear.php
+++ b/src/Creative/InLine/Linear.php
@@ -14,6 +14,7 @@ namespace Sokil\Vast\Creative\InLine;
 
 use Sokil\Vast\Creative\AbstractLinearCreative;
 use Sokil\Vast\Creative\InLine\Linear\ClosedCaptionFile;
+use Sokil\Vast\Creative\InLine\Linear\InteractiveCreativeFile;
 use Sokil\Vast\Creative\InLine\Linear\MediaFile;
 
 class Linear extends AbstractLinearCreative
@@ -93,6 +94,19 @@ class Linear extends AbstractLinearCreative
 
         // object
         return $this->vastElementBuilder->createInLineAdLinearCreativeMediaFile($mediaFileDomElement);
+    }
+
+    public function createInteractiveCreativeFile(): InteractiveCreativeFile
+    {
+        // get needed DOM element
+        $mediaFilesDomElement = $this->getMediaFilesElement();
+
+        // create MediaFile and append to MediaFiles
+        $mediaFileDomElement = $mediaFilesDomElement->ownerDocument->createElement('InteractiveCreativeFile');
+        $mediaFilesDomElement->appendChild($mediaFileDomElement);
+
+        // object
+        return $this->vastElementBuilder->createInlineAdLinearCreativeInteractiveCreativeMediaFile($mediaFileDomElement);
     }
 
     /**

--- a/src/Creative/InLine/Linear/InteractiveCreativeFile.php
+++ b/src/Creative/InLine/Linear/InteractiveCreativeFile.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the PHP-VAST package.
+ *
+ * (c) Dmytro Sokil <dmytro.sokil@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sokil\Vast\Creative\InLine\Linear;
+
+/**
+ * Optional node that enables interactive creative files associated with the ad media (video or audio)
+ * to be provided to the player.
+ *
+ * Compatible with VAST starting from version 4.0
+ *
+ * See section 3.9.3 of VAST specification version 4.1
+ *
+ * @author Bram Devries <bramdevries93@gmail.com>
+ */
+class InteractiveCreativeFile
+{
+    /**
+     * @var \DomElement
+     */
+    private $domElement;
+
+    /**
+     * @param \DomElement $domElement
+     */
+    public function __construct(\DomElement $domElement)
+    {
+        $this->domElement = $domElement;
+    }
+
+    /**
+     * Set file mime type
+     *
+     * @param string $mime Mime type of the file
+     */
+    public function setType(string $mime): self
+    {
+        $this->domElement->setAttribute('type', $mime);
+
+        return $this;
+    }
+
+    /**
+     * @param string $apiFramework the API needed to execute the resource file if applicable.
+     */
+    public function setApiFramework(string $apiFramework): self
+    {
+        $this->domElement->setAttribute('apiFramework', $apiFramework);
+
+        return $this;
+    }
+
+    /**
+     * Set file URL
+     *
+     * @param string $url URL of the file
+     */
+    public function setUrl(string $url): self
+    {
+        $cdata = $this->domElement->ownerDocument->createCDATASection($url);
+
+        // update CData
+        if ($this->domElement->hasChildNodes()) {
+            $this->domElement->replaceChild($cdata, $this->domElement->firstChild);
+        } // insert CData
+        else {
+            $this->domElement->appendChild($cdata);
+        }
+        return $this;
+    }
+}

--- a/src/ElementBuilder.php
+++ b/src/ElementBuilder.php
@@ -15,6 +15,7 @@ namespace Sokil\Vast;
 use Sokil\Vast\Ad\InLine;
 use Sokil\Vast\Ad\Wrapper;
 use Sokil\Vast\Creative\InLine\Linear as InLineAdLinearCreative;
+use Sokil\Vast\Creative\InLine\Linear\InteractiveCreativeFile;
 use Sokil\Vast\Creative\Wrapper\Linear as WrapperAdLinearCreative;
 use Sokil\Vast\Creative\InLine\Linear\MediaFile;
 use Sokil\Vast\Creative\InLine\Linear\ClosedCaptionFile;
@@ -98,7 +99,19 @@ class ElementBuilder
     {
         return new MediaFile($mediaFileDomElement);
     }
-    
+
+    /**
+     * <Ad><InLine><Creatives><Creative><Linear><MediaFiles><InteractiveCreativeFile>
+     *
+     * @param \DOMElement $mediaFileDomElement
+     *
+     * @return InteractiveCreativeFile
+     */
+    public function createInlineAdLinearCreativeInteractiveCreativeMediaFile(\DOMElement $mediaFileDomElement): InteractiveCreativeFile
+    {
+        return new InteractiveCreativeFile($mediaFileDomElement);
+    }
+
     /**
      * <Ad><InLine><Creatives><Creative><Linear><MediaFiles><ClosedCaptionFiles><ClosedCaptionFile>
      *

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -234,6 +234,7 @@ class DocumentTest extends AbstractTestCase
 
         $linear = $ad1->createLinearCreative();
         $linear->createMediaFile()->setStreamingDelivery();
+        $linear->createInteractiveCreativeFile()->setType('text/html')->setApiFramework('SIMID')->setUrl('http://example.com/index.html');
 
         $this->assertVastDocumentSameWithXmlFixture('linearCreativeWithInteractiveCreativeAndMediaFile.xml', $document);
     }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -217,6 +217,28 @@ class DocumentTest extends AbstractTestCase
     }
 
     /**
+     * Test for creating media file with Interactive Creative and Media Files
+     */
+    public function testCreateLinearCreativeWithInteractiveCreativeFileAndMedia()
+    {
+        $factory = new Factory();
+        $document = $factory->create('4.1');
+
+        // insert Ad section
+        $ad1 = $document
+            ->createInLineAdSection()
+            ->setId('ad1')
+            ->setAdSystem('Ad Server Name')
+            ->setAdTitle('Ad Title')
+            ->addImpression('http://ad.server.com/impression');
+
+        $linear = $ad1->createLinearCreative();
+        $linear->createMediaFile()->setStreamingDelivery();
+
+        $this->assertVastDocumentSameWithXmlFixture('linearCreativeWithInteractiveCreativeAndMediaFile.xml', $document);
+    }
+
+    /**
      * Test for creating media file with specific delivery
      */
     public function testCreateAdSectionWithDelivery()

--- a/tests/data/linearCreativeWithInteractiveCreativeAndMediaFile.xml
+++ b/tests/data/linearCreativeWithInteractiveCreativeAndMediaFile.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="4.1">
+    <Ad id="ad1">
+        <InLine>
+            <AdSystem><![CDATA[Ad Server Name]]></AdSystem>
+            <AdTitle><![CDATA[Ad Title]]></AdTitle>
+            <Impression><![CDATA[http://ad.server.com/impression]]></Impression>
+            <Creatives>
+                <Creative>
+                    <Linear>
+                        <MediaFiles>
+                            <MediaFile delivery="streaming"/>
+                            <InteractiveCreativeFile type="text/html" apiFramework="SIMID">
+                                <![CDATA[http://example.com/index.html]]>
+                            </InteractiveCreativeFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+            </Creatives>
+        </InLine>
+    </Ad>
+</VAST>


### PR DESCRIPTION
This introduces the `InteractiveCreativeFile` node as per the 4.1 VAST specification. It follows the same approach introduced in https://github.com/sokil/php-vast/pull/32